### PR TITLE
fix: don't go back from main menu to avoid crash from empty screen stack

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -338,9 +338,14 @@ impl<'a> App<'_> {
                 self.current_screen = self.screen_stack.last().unwrap().clone();
             }
             Some(_) => {
-                self.cursor = 0;
-                self.selected = None;
-                self.current_screen = self.screen_stack.last().unwrap().clone();
+                match self.screen_stack.last() {
+                    Some(screen) => {
+                        self.cursor = 0;
+                        self.selected = None;
+                        self.current_screen = screen.clone();
+                    }
+                    _ => {}
+                }
             }
             None => {}
         }


### PR DESCRIPTION
when hitting `j` in the main menu to go back, the program crashes because the screen stack is empty and the call to `self.screen_stack.last()` returns `None`.