### PR TITLE
[Screens] - Broke Screens & Widgets Down In To Slightly More Palatable Chunks. 

### DIFF
--- a/src/screens/downloads.rs
+++ b/src/screens/downloads.rs
@@ -1,0 +1,40 @@
+use tui::backend::Backend;
+use tui::widgets::ListState;
+use tui::Frame;
+
+use crate::app::App;
+use crate::display::inputopt::InputOpt;
+use crate::request::command::Command;
+use crate::request::wget::Wget;
+use crate::screens::screen::Screen;
+use crate::ui::widgets::{default_rect, menu_paragraph};
+
+pub fn handle_downloads_screen<B: Backend>(app: &mut App, frame: &mut Frame<'_, B>) {
+    app.command = Some(Command::Wget(Wget::new()));
+    let area = default_rect(frame.size());
+    let list = app.current_screen.get_list();
+    let mut state = ListState::with_selected(ListState::default(), Some(app.cursor));
+    app.items = app.current_screen.get_opts();
+    app.state = Some(state.clone());
+    app.state.as_mut().unwrap().select(Some(app.cursor));
+    frame.set_cursor(0, app.cursor as u16);
+    frame.render_stateful_widget(list, area, &mut state);
+    frame.render_widget(menu_paragraph(), frame.size());
+    match app.selected {
+        // Setting Recursion level
+        Some(0) => app.goto_screen(Screen::InputMenu(InputOpt::RecursiveDownload)),
+        // Add URL of download
+        Some(1) => app.goto_screen(Screen::InputMenu(InputOpt::URL)),
+        // Add file name for output/download
+        Some(2) => app.goto_screen(Screen::InputMenu(InputOpt::Output)),
+        // Execute command
+        Some(3) => {
+            if let Ok(response) = app.command.as_mut().unwrap().execute() {
+                app.response = Some(response.clone());
+                app.goto_screen(Screen::Success);
+            }
+        }
+        Some(_) => {}
+        None => {}
+    };
+}

--- a/src/screens/home.rs
+++ b/src/screens/home.rs
@@ -1,0 +1,34 @@
+use tui::backend::Backend;
+use tui::widgets::ListState;
+use tui::Frame;
+
+use crate::app::App;
+use crate::screens::screen::Screen;
+use crate::ui::widgets::{centered_rect, menu_paragraph};
+
+pub fn handle_home_screen<B: Backend>(app: &mut App, frame: &mut Frame<'_, B>) {
+    let new_list = app.current_screen.get_list();
+    let area = centered_rect(70, 60, frame.size());
+    let mut state = ListState::with_selected(ListState::default(), Some(app.cursor));
+    app.state = Some(state.clone());
+    app.state.as_mut().unwrap().select(Some(app.cursor));
+    frame.set_cursor(0, app.cursor as u16);
+    frame.render_stateful_widget(new_list, area, &mut state);
+    frame.render_widget(menu_paragraph(), frame.size());
+    match app.selected {
+        Some(0) => {
+            app.goto_screen(Screen::Method);
+        }
+        Some(1) => {
+            app.goto_screen(Screen::Downloads);
+        }
+        Some(2) => {
+            app.goto_screen(Screen::Keys);
+        }
+        Some(3) => {
+            app.goto_screen(Screen::Commands);
+        }
+        Some(_) => {}
+        None => {}
+    }
+}

--- a/src/screens/input.rs
+++ b/src/screens/input.rs
@@ -1,0 +1,195 @@
+use tui::backend::Backend;
+use tui::layout::{Constraint, Direction, Layout};
+use tui::style::{Color, Modifier, Style};
+use tui::text::{Line, Span, Text};
+use tui::widgets::{Block, Borders, Paragraph};
+use tui::Frame;
+
+use crate::app::{App, InputMode};
+use crate::display::displayopts::DisplayOpts;
+use crate::display::inputopt::InputOpt;
+use crate::screens::screen::Screen;
+
+/// Renders a screen we can grab input from, pass in the appropriate designation for the input
+pub fn render_input_screen<B: Backend>(app: &mut App, frame: &mut Frame<'_, B>, opt: InputOpt) {
+    match opt {
+        InputOpt::URL => render_default_input(app, frame, opt),
+        InputOpt::Headers => render_headers_input(app, frame, opt),
+        InputOpt::RecursiveDownload => render_recursive_download_input(app, frame, opt),
+        _ => render_default_input(app, frame, opt),
+    }
+}
+
+pub fn render_headers_input<B: Backend>(app: &mut App, frame: &mut Frame<'_, B>, opt: InputOpt) {
+    let header_prompt = Text::from(Line::from(
+        "MUST be \"Key:Value\" pair and press Enter \n Example: Content-Type: application/json",
+    ));
+    render_input_with_prompt(app, frame, header_prompt, opt);
+}
+
+pub fn render_input_with_prompt<B: Backend>(
+    _app: &mut App,
+    frame: &mut Frame<'_, B>,
+    prompt: Text,
+    _opt: InputOpt,
+) {
+    // Render the input with the provided prompt
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .margin(2)
+        .constraints(
+            [
+                Constraint::Length(1),
+                Constraint::Length(3),
+                Constraint::Min(1),
+            ]
+            .as_ref(),
+        )
+        .split(frame.size());
+
+    let message = Paragraph::new(prompt);
+    frame.render_widget(message, chunks[0]);
+}
+
+pub fn render_recursive_download_input<B: Backend>(
+    app: &mut App,
+    frame: &mut Frame<'_, B>,
+    opt: InputOpt,
+) {
+    let header_prompt = Text::from(Line::from(
+        "Enter the recursion level and press Enter \n Example: 2",
+    ));
+    render_input_with_prompt(app, frame, header_prompt, opt);
+}
+
+pub fn render_default_input<B: Backend>(app: &mut App, frame: &mut Frame<'_, B>, opt: InputOpt) {
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .margin(2)
+        .constraints(
+            [
+                Constraint::Length(1),
+                Constraint::Length(3),
+                Constraint::Min(1),
+            ]
+            .as_ref(),
+        )
+        .split(frame.size());
+    let (_msg, style) = match app.input_mode {
+        InputMode::Normal => (
+            vec![
+                Span::raw("Press "),
+                Span::styled("q", Style::default().add_modifier(Modifier::BOLD)),
+                Span::raw(" to exit, "),
+                Span::styled("i", Style::default().add_modifier(Modifier::BOLD)),
+                Span::raw(" to start editing."),
+            ],
+            Style::default().add_modifier(Modifier::RAPID_BLINK),
+        ),
+        InputMode::Editing => (
+            vec![
+                Span::raw("Press "),
+                Span::styled("Esc", Style::default().add_modifier(Modifier::BOLD)),
+                Span::raw(" to stop editing, "),
+                Span::styled("Enter", Style::default().add_modifier(Modifier::BOLD)),
+                Span::raw(" to submit."),
+            ],
+            Style::default(),
+        ),
+    };
+
+    let mut header_prompt = Text::from("Enter a value and press Enter");
+    header_prompt.patch_style(style);
+
+    render_input_with_prompt(app, frame, header_prompt, opt.clone());
+
+    let width = chunks[0].width.max(3) - 3; // keep 2 for borders and 1 for cursor
+
+    let scroll = app.input.visual_scroll(width as usize);
+    let input = Paragraph::new(app.input.value())
+        .style(match app.input_mode {
+            InputMode::Normal => Style::default(),
+            InputMode::Editing => Style::default().fg(Color::Yellow),
+        })
+        .scroll((0, scroll as u16))
+        .block(Block::default().borders(Borders::ALL).title("Input"));
+    frame.render_widget(input, chunks[1]);
+    match app.input_mode {
+        InputMode::Normal => {}
+        InputMode::Editing => frame.set_cursor(
+            chunks[1].x + ((app.input.visual_cursor()).max(scroll) - scroll) as u16 + 1,
+            chunks[1].y + 1,
+        ),
+    }
+
+    if !app.messages.is_empty() {
+        match opt {
+            InputOpt::URL => {
+                app.command
+                    .as_mut()
+                    .unwrap()
+                    .set_url(app.messages[0].clone());
+                app.input_mode = InputMode::Normal;
+                app.add_display_option(DisplayOpts::URL(app.messages[0].clone()));
+                app.current_screen = Screen::RequestMenu(String::new());
+                app.messages.remove(0);
+            }
+
+            InputOpt::Headers => {
+                let headers = app
+                    .messages
+                    .get(0)
+                    .unwrap()
+                    .split(':')
+                    .collect::<Vec<&str>>();
+                let cpy = (
+                    String::from(headers[0].clone()),
+                    String::from(headers[1].clone()),
+                );
+                app.command
+                    .as_mut()
+                    .unwrap()
+                    .set_headers(headers.iter().map(|x| x.to_string()).collect());
+                app.add_display_option(DisplayOpts::Headers(cpy));
+                app.current_screen = Screen::RequestMenu(String::new());
+                app.messages.remove(0);
+            }
+
+            InputOpt::Output => {
+                app.command
+                    .as_mut()
+                    .unwrap()
+                    .set_outfile(app.messages[0].clone());
+                app.add_display_option(DisplayOpts::Outfile(app.messages[0].clone()));
+                app.messages.remove(0);
+                app.goto_screen(Screen::RequestMenu(String::new()));
+            }
+
+            InputOpt::Execute => {
+                // This means they have executed the command, and want to write to a file
+                app.command
+                    .as_mut()
+                    .unwrap()
+                    .set_outfile(app.messages[0].clone());
+                match app.command.as_mut().unwrap().write_output() {
+                    Ok(_) => {
+                        app.goto_screen(Screen::Success);
+                    }
+                    Err(e) => {
+                        app.goto_screen(Screen::Error(e.to_string()));
+                    }
+                }
+                app.goto_screen(Screen::Home);
+            }
+
+            InputOpt::RecursiveDownload => {
+                let recursion_level = app.messages[0].parse::<usize>().unwrap();
+                app.command
+                    .as_mut()
+                    .unwrap()
+                    .set_rec_download_level(recursion_level);
+            }
+            _ => {}
+        }
+    }
+}

--- a/src/screens/keys.rs
+++ b/src/screens/keys.rs
@@ -1,0 +1,40 @@
+use tui::backend::Backend;
+use tui::layout::Alignment;
+use tui::style::{Color, Style};
+use tui::widgets::{Block, BorderType, Borders, ListState, Paragraph};
+use tui::Frame;
+
+use crate::app::App;
+use crate::ui::widgets::default_rect;
+
+pub fn handle_api_key_screen<B: Backend>(app: &mut App, frame: &mut Frame<'_, B>) {
+    let area = default_rect(frame.size());
+    let new_list = app.current_screen.get_list();
+    let mut state = ListState::with_selected(ListState::default(), Some(app.cursor));
+    if !app.items.is_empty() {
+        app.items.clear();
+    }
+    app.items = app.current_screen.get_opts();
+    app.state = Some(state.clone());
+    app.state.as_mut().unwrap().select(Some(app.cursor));
+
+    frame.set_cursor(0, app.cursor as u16);
+    frame.render_stateful_widget(new_list, area, &mut state);
+    frame.render_widget(api_key_paragraph(), frame.size());
+}
+
+pub fn api_key_paragraph() -> Paragraph<'static> {
+    Paragraph::new(
+        "Create / Edit / Delete API Keys and tokens.\n
+                    Press q to exit \n Press Enter to select \n Please select a Menu item\n",
+    )
+    .block(
+        Block::default()
+            .title("API Key Manager")
+            .title_alignment(Alignment::Center)
+            .borders(Borders::ALL)
+            .border_type(BorderType::Rounded),
+    )
+    .style(Style::default().fg(Color::Cyan).bg(Color::Black))
+    .alignment(Alignment::Center)
+}

--- a/src/screens/method.rs
+++ b/src/screens/method.rs
@@ -1,0 +1,35 @@
+use tui::backend::Backend;
+use tui::widgets::ListState;
+use tui::Frame;
+
+use crate::app::App;
+use crate::display::menuopts::METHOD_MENU_OPTIONS;
+use crate::request::command::Command;
+use crate::request::curl::Curl;
+use crate::screens::screen::Screen;
+use crate::ui::widgets::{default_rect, menu_paragraph};
+
+pub fn handle_method_select_screen<B: Backend>(app: &mut App, frame: &mut Frame<'_, B>) {
+    let area = default_rect(frame.size());
+    let new_list = app.current_screen.get_list();
+    let mut state = ListState::with_selected(ListState::default(), Some(app.cursor));
+    app.items = app.current_screen.get_opts();
+    app.state = Some(state.clone());
+    app.state.as_mut().unwrap().select(Some(app.cursor));
+    frame.set_cursor(0, app.cursor as u16);
+    frame.render_stateful_widget(new_list, area, &mut state);
+    frame.render_widget(menu_paragraph(), frame.size());
+    app.command = Some(Command::Curl(Curl::new()));
+    match app.selected {
+        Some(num) => {
+            app.command
+                .as_mut()
+                .unwrap()
+                .set_method(String::from(METHOD_MENU_OPTIONS[num])); // safe index
+            app.goto_screen(Screen::RequestMenu(String::from(
+                METHOD_MENU_OPTIONS[num].clone(),
+            )));
+        }
+        None => {}
+    }
+}

--- a/src/screens/mod.rs
+++ b/src/screens/mod.rs
@@ -1,1 +1,28 @@
 pub mod screen;
+
+// Home Screen
+pub mod home;
+
+// Input Screen
+pub mod input;
+
+// API Keys
+pub mod keys;
+
+// Downloads Screen
+pub mod downloads;
+
+// Method Select Screens
+pub mod method;
+
+// Request Select Screens
+pub mod request;
+
+// Success Screen
+pub mod success;
+
+// Response Screen
+pub mod response;
+
+// View Body Screen
+pub mod viewbody;

--- a/src/screens/request.rs
+++ b/src/screens/request.rs
@@ -1,0 +1,74 @@
+use tui::backend::Backend;
+use tui::widgets::ListState;
+use tui::Frame;
+
+use crate::app::App;
+use crate::display::displayopts::DisplayOpts;
+use crate::display::inputopt::InputOpt;
+use crate::screens::screen::Screen;
+use crate::ui::widgets::{default_rect, menu_paragraph};
+
+pub fn handle_request_menu_screen<B: Backend>(app: &mut App, frame: &mut Frame<'_, B>) {
+    let area = default_rect(frame.size());
+    let new_list = app.current_screen.get_list();
+    let mut state = ListState::with_selected(ListState::default(), Some(app.cursor));
+    if !app.items.is_empty() {
+        app.items.clear();
+    }
+    app.items = app.current_screen.get_opts();
+    app.state = Some(state.clone());
+    app.state.as_mut().unwrap().select(Some(app.cursor));
+    frame.set_cursor(0, app.cursor as u16);
+    frame.render_stateful_widget(new_list, area, &mut state);
+    frame.render_widget(menu_paragraph(), frame.size());
+    match app.selected {
+        Some(num) => match num {
+            // Add a URL,
+            0 => app.goto_screen(Screen::InputMenu(InputOpt::URL)),
+            // Auth
+            1 => app.goto_screen(Screen::InputMenu(InputOpt::Authentication)),
+            // Headers
+            2 => app.goto_screen(Screen::InputMenu(InputOpt::Headers)),
+            // Verbose
+            3 => {
+                if app.opts.contains(&DisplayOpts::Verbose) {
+                    app.opts.retain(|x| x != &DisplayOpts::Verbose);
+                    app.command.as_mut().unwrap().set_verbose(false);
+                } else {
+                    app.add_display_option(DisplayOpts::Verbose);
+                    app.command.as_mut().unwrap().set_verbose(true);
+                }
+                app.selected = None;
+            }
+            // Output file,
+            4 => {
+                app.goto_screen(Screen::InputMenu(InputOpt::Output));
+                app.selected = None;
+            }
+            // Request Body
+            5 => {
+                app.goto_screen(Screen::InputMenu(InputOpt::RequestBody));
+                app.selected = None;
+            }
+            // Save this command
+            6 => {
+                app.goto_screen(Screen::Commands);
+                app.selected = None;
+            }
+            // Recursive download
+            7 => {
+                app.selected = None;
+                app.goto_screen(Screen::InputMenu(InputOpt::RecursiveDownload));
+            }
+            // Execute command
+            8 => {
+                if let Ok(response) = app.command.as_mut().unwrap().execute() {
+                    app.set_response(response.clone());
+                    app.goto_screen(Screen::Response(response));
+                }
+            }
+            _ => {}
+        },
+        None => {}
+    }
+}

--- a/src/screens/response.rs
+++ b/src/screens/response.rs
@@ -1,0 +1,45 @@
+use tui::backend::Backend;
+use tui::layout::Alignment;
+use tui::style::{Color, Style};
+use tui::text::Text;
+use tui::widgets::{ListState, Paragraph};
+use tui::Frame;
+
+use crate::app::App;
+use crate::display::inputopt::InputOpt;
+use crate::screens::screen::Screen;
+use crate::ui::widgets::{default_rect, small_alert_box};
+
+pub fn handle_response_screen<B: Backend>(app: &mut App, frame: &mut Frame<'_, B>, resp: String) {
+    let area = default_rect(small_alert_box(frame.size()));
+    let new_list = app.current_screen.get_list();
+    let mut state = ListState::with_selected(ListState::default(), Some(app.cursor));
+    let paragraph = Paragraph::new(Text::from(resp.as_str()))
+        .style(Style::default().fg(Color::Yellow).bg(Color::Black))
+        .alignment(Alignment::Center);
+    if !app.items.is_empty() {
+        app.items.clear();
+    }
+    app.items = app.current_screen.get_opts();
+    app.state = Some(state.clone());
+    app.state.as_mut().unwrap().select(Some(app.cursor));
+    frame.set_cursor(0, app.cursor as u16);
+    frame.render_stateful_widget(new_list, area, &mut state);
+    let area_2 = small_alert_box(frame.size());
+    frame.render_widget(paragraph, area_2);
+    match app.selected {
+        Some(num) => match num {
+            0 => {
+                app.goto_screen(Screen::InputMenu(InputOpt::Output));
+            }
+            1 => {
+                app.goto_screen(Screen::Commands);
+            }
+            2 => {
+                app.goto_screen(Screen::ViewBody);
+            }
+            _ => {}
+        },
+        None => {}
+    }
+}

--- a/src/screens/success.rs
+++ b/src/screens/success.rs
@@ -1,0 +1,12 @@
+use tui::backend::Backend;
+use tui::Frame;
+
+use crate::app::App;
+use crate::ui::widgets::{default_rect, menu_paragraph};
+
+pub fn handle_success_screen<B: Backend>(app: &mut App, frame: &mut Frame<'_, B>) {
+    let area = default_rect(frame.size());
+    app.items = app.current_screen.get_opts();
+    frame.set_cursor(0, app.cursor as u16);
+    frame.render_widget(menu_paragraph(), area);
+}

--- a/src/screens/viewbody.rs
+++ b/src/screens/viewbody.rs
@@ -1,0 +1,20 @@
+use tui::backend::Backend;
+use tui::layout::Alignment;
+use tui::style::{Color, Style};
+use tui::text::Text;
+use tui::widgets::Paragraph;
+use tui::Frame;
+
+use crate::app::App;
+use crate::ui::widgets::small_rect;
+
+pub fn handle_view_body_screen<B: Backend>(app: &mut App, frame: &mut Frame<'_, B>) {
+    // screen with only the body of the response
+    app.items.clear();
+    let area = small_rect(frame.size());
+    let response = app.response.clone().unwrap();
+    let paragraph = Paragraph::new(Text::from(response.as_str()))
+        .style(Style::default().fg(Color::Yellow).bg(Color::Black))
+        .alignment(Alignment::Center);
+    frame.render_widget(paragraph, area);
+}

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -2,3 +2,4 @@
 pub mod tui;
 
 pub mod render;
+pub mod widgets;

--- a/src/ui/render.rs
+++ b/src/ui/render.rs
@@ -1,20 +1,33 @@
 use tui::{
     backend::Backend,
-    layout::{Alignment, Constraint, Direction, Layout, Rect},
-    style::{Color, Modifier, Style},
-    text::{Line, Span, Text},
-    widgets::{Block, BorderType, Borders, ListState, Paragraph},
+    layout::Alignment,
+    style::{Color, Style},
+    text::Text,
+    widgets::{Block, BorderType, Borders, Paragraph},
     Frame,
 };
 
-use crate::app::{App, InputMode};
+use crate::app::App;
 use crate::display::displayopts::DisplayOpts;
+
+use crate::screens::downloads::handle_downloads_screen;
+use crate::screens::home::handle_home_screen;
+use crate::screens::input::render_input_screen;
+use crate::screens::keys::handle_api_key_screen;
+use crate::screens::method::handle_method_select_screen;
+use crate::screens::request::handle_request_menu_screen;
+use crate::screens::response::handle_response_screen;
+
 use crate::display::inputopt::InputOpt;
 use crate::display::menuopts::METHOD_MENU_OPTIONS;
 use crate::request::command::Command;
 use crate::request::curl::Curl;
 use crate::request::wget::Wget;
+
 use crate::screens::screen::Screen;
+use crate::screens::success::handle_success_screen;
+use crate::screens::viewbody::handle_view_body_screen;
+use crate::ui::widgets::small_rect;
 
 pub static CURL: &str = "curl";
 pub static WGET: &str = "wget";
@@ -66,176 +79,33 @@ pub fn render<B: Backend>(app: &mut App, frame: &mut Frame<'_, B>) {
     match &app.current_screen.clone() {
         // HOME SCREEN ******************************************************
         Screen::Home => {
-            let new_list = app.current_screen.get_list();
-            let area = centered_rect(70, 60, frame.size());
-            let mut state = ListState::with_selected(ListState::default(), Some(app.cursor));
-            app.state = Some(state.clone());
-            app.state.as_mut().unwrap().select(Some(app.cursor));
-            frame.set_cursor(0, app.cursor as u16);
-            frame.render_stateful_widget(new_list, area, &mut state);
-            frame.render_widget(menu_paragraph(), frame.size());
-            match app.selected {
-                Some(0) => {
-                    app.goto_screen(Screen::Method);
-                }
-                Some(1) => {
-                    app.goto_screen(Screen::Downloads);
-                }
-                Some(2) => {
-                    app.goto_screen(Screen::Keys);
-                }
-                Some(3) => {
-                    app.goto_screen(Screen::Commands);
-                }
-                Some(_) => {}
-                None => {}
-            }
+            handle_home_screen(app, frame);
         }
 
         // METHOD SCREEN ****************************************************
         Screen::Method => {
-            let area = default_rect(frame.size());
-            let new_list = app.current_screen.get_list();
-            let mut state = ListState::with_selected(ListState::default(), Some(app.cursor));
-            app.items = app.current_screen.get_opts();
-            app.state = Some(state.clone());
-            app.state.as_mut().unwrap().select(Some(app.cursor));
-            frame.set_cursor(0, app.cursor as u16);
-            frame.render_stateful_widget(new_list, area, &mut state);
-            frame.render_widget(menu_paragraph(), frame.size());
-            app.command = Some(Command::Curl(Curl::new()));
-            match app.selected {
-                Some(num) => {
-                    app.command
-                        .as_mut()
-                        .unwrap()
-                        .set_method(String::from(METHOD_MENU_OPTIONS[num])); // safe index
-                    app.goto_screen(Screen::RequestMenu(String::from(
-                        METHOD_MENU_OPTIONS[num].clone(),
-                    )));
-                }
-                None => {}
-            }
+
+            handle_method_select_screen(app, frame);
         }
 
+        // DOWNLOAD SCREEN **************************************************
         Screen::Downloads => {
-            app.command = Some(Command::Wget(Wget::new()));
-            let area = default_rect(frame.size());
-            let list = app.current_screen.get_list();
-            let mut state = ListState::with_selected(ListState::default(), Some(app.cursor));
-            app.items = app.current_screen.get_opts();
-            app.state = Some(state.clone());
-            app.state.as_mut().unwrap().select(Some(app.cursor));
-            frame.set_cursor(0, app.cursor as u16);
-            frame.render_stateful_widget(list, area, &mut state);
-            frame.render_widget(menu_paragraph(), frame.size());
-            match app.selected {
-                // Setting Recursion level
-                Some(0) => app.goto_screen(Screen::InputMenu(InputOpt::RecursiveDownload)),
-                // Add URL of download
-                Some(1) => app.goto_screen(Screen::InputMenu(InputOpt::URL)),
-                // Add file name for output/download
-                Some(2) => app.goto_screen(Screen::InputMenu(InputOpt::Output)),
-                // Execute command
-                Some(3) => {
-                    if let Ok(response) = app.command.as_mut().unwrap().execute() {
-                        app.response = Some(response.clone());
-                        app.goto_screen(Screen::Success);
-                    }
-                }
-                Some(_) => {}
-                None => {}
-            };
+            handle_downloads_screen(app, frame);
         }
+
         // KEYS SCREEN **********************************************
         Screen::Keys => {
-            let area = default_rect(frame.size());
-            let new_list = app.current_screen.get_list();
-            let mut state = ListState::with_selected(ListState::default(), Some(app.cursor));
-            if !app.items.is_empty() {
-                app.items.clear();
-            }
-            app.items = app.current_screen.get_opts();
-            app.state = Some(state.clone());
-            app.state.as_mut().unwrap().select(Some(app.cursor));
-
-            frame.set_cursor(0, app.cursor as u16);
-            frame.render_stateful_widget(new_list, area, &mut state);
-            frame.render_widget(api_key_paragraph(), frame.size());
+            handle_api_key_screen(app, frame);
         }
 
         // REQUEST MENU SCREEN **********************************************
         Screen::RequestMenu(_) => {
-            let area = default_rect(frame.size());
-            let new_list = app.current_screen.get_list();
-            let mut state = ListState::with_selected(ListState::default(), Some(app.cursor));
-            if !app.items.is_empty() {
-                app.items.clear();
-            }
-            app.items = app.current_screen.get_opts();
-            app.state = Some(state.clone());
-            app.state.as_mut().unwrap().select(Some(app.cursor));
-            frame.set_cursor(0, app.cursor as u16);
-            frame.render_stateful_widget(new_list, area, &mut state);
-            frame.render_widget(menu_paragraph(), frame.size());
-            match app.selected {
-                Some(num) => match num {
-                    // Add a URL,
-                    0 => app.goto_screen(Screen::InputMenu(InputOpt::URL)),
-                    // Auth
-                    1 => app.goto_screen(Screen::InputMenu(InputOpt::Authentication)),
-                    // Headers
-                    2 => app.goto_screen(Screen::InputMenu(InputOpt::Headers)),
-                    // Verbose
-                    3 => {
-                        if app.opts.contains(&DisplayOpts::Verbose) {
-                            app.opts.retain(|x| x != &DisplayOpts::Verbose);
-                            app.command.as_mut().unwrap().set_verbose(false);
-                        } else {
-                            app.add_display_option(DisplayOpts::Verbose);
-                            app.command.as_mut().unwrap().set_verbose(true);
-                        }
-                        app.selected = None;
-                    }
-                    // Output file,
-                    4 => {
-                        app.goto_screen(Screen::InputMenu(InputOpt::Output));
-                        app.selected = None;
-                    }
-                    // Request Body
-                    5 => {
-                        app.goto_screen(Screen::InputMenu(InputOpt::RequestBody));
-                        app.selected = None;
-                    }
-                    // Save this command
-                    6 => {
-                        app.goto_screen(Screen::Commands);
-                        app.selected = None;
-                    }
-                    // Recursive download
-                    7 => {
-                        app.selected = None;
-                        app.goto_screen(Screen::InputMenu(InputOpt::RecursiveDownload));
-                    }
-                    // Execute command
-                    8 => {
-                        if let Ok(response) = app.command.as_mut().unwrap().execute() {
-                            app.set_response(response.clone());
-                            app.goto_screen(Screen::Response(response));
-                        }
-                    }
-                    _ => {}
-                },
-                None => {}
-            }
+            handle_request_menu_screen(app, frame);
         }
 
         // SUCESSS SCREEN *********************************************************
         Screen::Success => {
-            let area = default_rect(frame.size());
-            app.items = app.current_screen.get_opts();
-            frame.set_cursor(0, app.cursor as u16);
-            frame.render_widget(menu_paragraph(), area);
+            handle_success_screen(app, frame);
         }
 
         // INPUT MENU SCREEN *****************************************************
@@ -245,250 +115,17 @@ pub fn render<B: Backend>(app: &mut App, frame: &mut Frame<'_, B>) {
 
         // RESPONSE SCREEN ******************************************************
         Screen::Response(resp) => {
-            let area = default_rect(small_alert_box(frame.size()));
-            let new_list = app.current_screen.get_list();
-            let mut state = ListState::with_selected(ListState::default(), Some(app.cursor));
-            let paragraph = Paragraph::new(Text::from(resp.as_str()))
-                .style(Style::default().fg(Color::Yellow).bg(Color::Black))
-                .alignment(Alignment::Center);
-            if !app.items.is_empty() {
-                app.items.clear();
-            }
-            app.items = app.current_screen.get_opts();
-            app.state = Some(state.clone());
-            app.state.as_mut().unwrap().select(Some(app.cursor));
-            frame.set_cursor(0, app.cursor as u16);
-            frame.render_stateful_widget(new_list, area, &mut state);
-            let area_2 = small_alert_box(frame.size());
-            frame.render_widget(paragraph, area_2);
-            match app.selected {
-                Some(num) => match num {
-                    0 => {
-                        app.goto_screen(Screen::InputMenu(InputOpt::Output));
-                    }
-                    1 => {
-                        app.goto_screen(Screen::Commands);
-                    }
-                    2 => {
-                        app.goto_screen(Screen::ViewBody);
-                    }
-                    _ => {}
-                },
-                None => {}
-            }
+            handle_response_screen(app, frame, resp.clone());
         }
 
         // VIEW BODY ********************************************************************
         Screen::ViewBody => {
-            // screen with only the body of the response
-            app.items.clear();
-            let area = small_rect(frame.size());
-            let response = app.response.clone().unwrap();
-            let paragraph = Paragraph::new(Text::from(response.as_str()))
-                .style(Style::default().fg(Color::Yellow).bg(Color::Black))
-                .alignment(Alignment::Center);
-            frame.render_widget(paragraph, area);
+            handle_view_body_screen(app, frame);
         }
         _ => {}
     }
 }
 
-/// Renders a screen we can grab input from, pass in the appropriate designation for the input
-fn render_input_screen<B: Backend>(app: &mut App, frame: &mut Frame<'_, B>, opt: InputOpt) {
-    match opt {
-        InputOpt::URL => render_default_input(app, frame, opt),
-        InputOpt::Headers => render_headers_input(app, frame, opt),
-        InputOpt::RecursiveDownload => render_recursive_download_input(app, frame, opt),
-        _ => render_default_input(app, frame, opt),
-    }
-}
-
-fn render_headers_input<B: Backend>(app: &mut App, frame: &mut Frame<'_, B>, opt: InputOpt) {
-    let header_prompt = Text::from(Line::from(
-        "MUST be \"Key:Value\" pair and press Enter \n Example: Content-Type: application/json",
-    ));
-    render_input_with_prompt(app, frame, header_prompt, opt);
-}
-
-fn render_recursive_download_input<B: Backend>(
-    app: &mut App,
-    frame: &mut Frame<'_, B>,
-    opt: InputOpt,
-) {
-    let header_prompt = Text::from(Line::from(
-        "Enter the recursion level and press Enter \n Example: 2",
-    ));
-    render_input_with_prompt(app, frame, header_prompt, opt);
-}
-
-fn render_default_input<B: Backend>(app: &mut App, frame: &mut Frame<'_, B>, opt: InputOpt) {
-    let chunks = Layout::default()
-        .direction(Direction::Vertical)
-        .margin(2)
-        .constraints(
-            [
-                Constraint::Length(1),
-                Constraint::Length(3),
-                Constraint::Min(1),
-            ]
-            .as_ref(),
-        )
-        .split(frame.size());
-    let (_msg, style) = match app.input_mode {
-        InputMode::Normal => (
-            vec![
-                Span::raw("Press "),
-                Span::styled("q", Style::default().add_modifier(Modifier::BOLD)),
-                Span::raw(" to exit, "),
-                Span::styled("i", Style::default().add_modifier(Modifier::BOLD)),
-                Span::raw(" to start editing."),
-            ],
-            Style::default().add_modifier(Modifier::RAPID_BLINK),
-        ),
-        InputMode::Editing => (
-            vec![
-                Span::raw("Press "),
-                Span::styled("Esc", Style::default().add_modifier(Modifier::BOLD)),
-                Span::raw(" to stop editing, "),
-                Span::styled("Enter", Style::default().add_modifier(Modifier::BOLD)),
-                Span::raw(" to submit."),
-            ],
-            Style::default(),
-        ),
-    };
-
-    let mut header_prompt = Text::from("Enter a value and press Enter");
-    header_prompt.patch_style(style);
-
-    render_input_with_prompt(app, frame, header_prompt, opt.clone());
-
-    let width = chunks[0].width.max(3) - 3; // keep 2 for borders and 1 for cursor
-
-    let scroll = app.input.visual_scroll(width as usize);
-    let input = Paragraph::new(app.input.value())
-        .style(match app.input_mode {
-            InputMode::Normal => Style::default(),
-            InputMode::Editing => Style::default().fg(Color::Yellow),
-        })
-        .scroll((0, scroll as u16))
-        .block(Block::default().borders(Borders::ALL).title("Input"));
-    frame.render_widget(input, chunks[1]);
-    match app.input_mode {
-        InputMode::Normal => {}
-        InputMode::Editing => frame.set_cursor(
-            chunks[1].x + ((app.input.visual_cursor()).max(scroll) - scroll) as u16 + 1,
-            chunks[1].y + 1,
-        ),
-    }
-
-    if !app.messages.is_empty() {
-        match opt {
-            InputOpt::URL => {
-                app.command
-                    .as_mut()
-                    .unwrap()
-                    .set_url(app.messages[0].clone());
-                app.input_mode = InputMode::Normal;
-                app.add_display_option(DisplayOpts::URL(app.messages[0].clone()));
-                app.current_screen = Screen::RequestMenu(String::new());
-                app.messages.remove(0);
-            }
-
-            InputOpt::Headers => {
-                let headers = app
-                    .messages
-                    .get(0)
-                    .unwrap()
-                    .split(':')
-                    .collect::<Vec<&str>>();
-                let cpy = (
-                    String::from(headers[0].clone()),
-                    String::from(headers[1].clone()),
-                );
-                app.command
-                    .as_mut()
-                    .unwrap()
-                    .set_headers(headers.iter().map(|x| x.to_string()).collect());
-                app.add_display_option(DisplayOpts::Headers(cpy));
-                app.current_screen = Screen::RequestMenu(String::new());
-                app.messages.remove(0);
-            }
-
-            InputOpt::Output => {
-                app.command
-                    .as_mut()
-                    .unwrap()
-                    .set_outfile(app.messages[0].clone());
-                app.add_display_option(DisplayOpts::Outfile(app.messages[0].clone()));
-                app.messages.remove(0);
-                app.goto_screen(Screen::RequestMenu(String::new()));
-            }
-
-            InputOpt::Execute => {
-                // This means they have executed the command, and want to write to a file
-                app.command
-                    .as_mut()
-                    .unwrap()
-                    .set_outfile(app.messages[0].clone());
-                match app.command.as_mut().unwrap().write_output() {
-                    Ok(_) => {
-                        app.goto_screen(Screen::Success);
-                    }
-                    Err(e) => {
-                        app.goto_screen(Screen::Error(e.to_string()));
-                    }
-                }
-                app.goto_screen(Screen::Home);
-            }
-
-            InputOpt::RecursiveDownload => {
-                let recursion_level = app.messages[0].parse::<usize>().unwrap();
-                app.command
-                    .as_mut()
-                    .unwrap()
-                    .set_rec_download_level(recursion_level);
-            }
-            _ => {}
-        }
-    }
-}
-
-fn render_input_with_prompt<B: Backend>(
-    _app: &mut App,
-    frame: &mut Frame<'_, B>,
-    prompt: Text,
-    _opt: InputOpt,
-) {
-    // Render the input with the provided prompt
-    let chunks = Layout::default()
-        .direction(Direction::Vertical)
-        .margin(2)
-        .constraints(
-            [
-                Constraint::Length(1),
-                Constraint::Length(3),
-                Constraint::Min(1),
-            ]
-            .as_ref(),
-        )
-        .split(frame.size());
-
-    let message = Paragraph::new(prompt);
-    frame.render_widget(message, chunks[0]);
-}
-
-fn menu_paragraph() -> Paragraph<'static> {
-    Paragraph::new("\nPress q to exit \n Press Enter to select \n Please select a Menu item\n")
-        .block(
-            Block::default()
-                .title("cURL-TUI")
-                .title_alignment(Alignment::Center)
-                .borders(Borders::ALL)
-                .border_type(BorderType::Rounded),
-        )
-        .style(Style::default().fg(Color::Cyan).bg(Color::Black))
-        .alignment(Alignment::Center)
-}
 
 /* Never Used
 fn success_paragraph() -> Paragraph<'static> {
@@ -504,65 +141,3 @@ fn success_paragraph() -> Paragraph<'static> {
         .alignment(Alignment::Center)
 }
  */
-
-fn api_key_paragraph() -> Paragraph<'static> {
-    Paragraph::new(
-        "Create / Edit / Delete API Keys and tokens.\n
-                    Press q to exit \n Press Enter to select \n Please select a Menu item\n",
-    )
-    .block(
-        Block::default()
-            .title("API Key Manager")
-            .title_alignment(Alignment::Center)
-            .borders(Borders::ALL)
-            .border_type(BorderType::Rounded),
-    )
-    .style(Style::default().fg(Color::Cyan).bg(Color::Black))
-    .alignment(Alignment::Center)
-}
-
-fn small_rect(r: Rect) -> Rect {
-    let layout = Layout::default()
-        .direction(Direction::Vertical) // Set the direction to horizontal
-        .constraints(vec![
-            Constraint::Percentage(85), // Occupy 85% of the available space
-            Constraint::Percentage(15), // Occupy 15% of the available space
-        ])
-        .split(r);
-    // Now, `layout` contains the two Rects based on the constraints
-    layout[1]
-}
-
-fn centered_rect(percent_x: u16, percent_y: u16, r: Rect) -> Rect {
-    let popup_layout = tui::layout::Layout::default()
-        .direction(tui::layout::Direction::Vertical)
-        .constraints(
-            [
-                Constraint::Percentage((100 - percent_y) / 2),
-                Constraint::Percentage(percent_y),
-                Constraint::Percentage((100 - percent_y) / 2),
-            ]
-            .as_ref(),
-        )
-        .split(r);
-
-    tui::layout::Layout::default()
-        .direction(tui::layout::Direction::Horizontal)
-        .constraints(
-            [
-                Constraint::Percentage((100 - percent_x) / 2),
-                Constraint::Percentage(percent_x),
-                Constraint::Percentage((100 - percent_x) / 2),
-            ]
-            .as_ref(),
-        )
-        .split(popup_layout[1])[1]
-}
-
-fn small_alert_box(r: Rect) -> Rect {
-    centered_rect(70, 60, r)
-}
-
-fn default_rect(r: Rect) -> Rect {
-    centered_rect(70, 60, r)
-}

--- a/src/ui/widgets.rs
+++ b/src/ui/widgets.rs
@@ -1,0 +1,64 @@
+//* These Should Be Smaller Reusable Components
+
+use tui::layout::{Alignment, Constraint, Direction, Layout, Rect};
+use tui::style::{Color, Style};
+use tui::widgets::{Block, BorderType, Borders, Paragraph};
+
+pub fn small_alert_box(r: Rect) -> Rect {
+    centered_rect(70, 60, r)
+}
+
+pub fn default_rect(r: Rect) -> Rect {
+    centered_rect(70, 60, r)
+}
+
+pub fn centered_rect(percent_x: u16, percent_y: u16, r: Rect) -> Rect {
+    let popup_layout = tui::layout::Layout::default()
+        .direction(tui::layout::Direction::Vertical)
+        .constraints(
+            [
+                Constraint::Percentage((100 - percent_y) / 2),
+                Constraint::Percentage(percent_y),
+                Constraint::Percentage((100 - percent_y) / 2),
+            ]
+            .as_ref(),
+        )
+        .split(r);
+
+    tui::layout::Layout::default()
+        .direction(tui::layout::Direction::Horizontal)
+        .constraints(
+            [
+                Constraint::Percentage((100 - percent_x) / 2),
+                Constraint::Percentage(percent_x),
+                Constraint::Percentage((100 - percent_x) / 2),
+            ]
+            .as_ref(),
+        )
+        .split(popup_layout[1])[1]
+}
+
+pub fn small_rect(r: Rect) -> Rect {
+    let layout = Layout::default()
+        .direction(Direction::Vertical) // Set the direction to horizontal
+        .constraints(vec![
+            Constraint::Percentage(85), // Occupy 85% of the available space
+            Constraint::Percentage(15), // Occupy 15% of the available space
+        ])
+        .split(r);
+    // Now, `layout` contains the two Rects based on the constraints
+    layout[1]
+}
+
+pub fn menu_paragraph() -> Paragraph<'static> {
+    Paragraph::new("\nPress q to exit \n Press Enter to select \n Please select a Menu item\n")
+        .block(
+            Block::default()
+                .title("cURL-TUI")
+                .title_alignment(Alignment::Center)
+                .borders(Borders::ALL)
+                .border_type(BorderType::Rounded),
+        )
+        .style(Style::default().fg(Color::Cyan).bg(Color::Black))
+        .alignment(Alignment::Center)
+}


### PR DESCRIPTION
I tried to be smart about the relationship between a lot of these functions and I think I've got it right. There are a few widgets that are used over and over again. Those now live in ui::widgets, and then we have several different screens being matched for in ui::render, and each match arm now gets handled by a function for the screen in its own file. So if we wanted to add a new screen we now add a new file to screens.rs and then add a new match arm in render.rs.

If we want to add a new small display widget we can add that in widgets. I feel like I can now start working on our different input screen ideas.

Additionally, I haven't done this yet, but im likely going to add a Debug menu for the purposes of debugging individual screens without having to worry about its place between screens or within some kind of bigger feature.