### PR TITLE
Fixes issue that crashes the app when alt-tabbing away and back from it.

### DIFF
--- a/src/events/event.rs
+++ b/src/events/event.rs
@@ -48,7 +48,9 @@ impl EventHandler {
                             CrosstermEvent::Key(e) => sender.send(Event::Key(e)),
                             CrosstermEvent::Mouse(e) => sender.send(Event::Mouse(e)),
                             CrosstermEvent::Resize(w, h) => sender.send(Event::Resize(w, h)),
-                            _ => unimplemented!(),
+                            CrosstermEvent::FocusGained => {sender.send(Event::Tick)}
+                            CrosstermEvent::FocusLost => {sender.send(Event::Tick)}
+                            CrosstermEvent::Paste(_s) => sender.send(Event::Tick),
                         }
                         .expect("failed to send terminal event")
                     }


### PR DESCRIPTION
Because these events were causing unimplemented!() to be executed. Now they just send a tick.

```rust
                            CrosstermEvent::FocusGained => {sender.send(Event::Tick)}
                            CrosstermEvent::FocusLost => {sender.send(Event::Tick)}
                            CrosstermEvent::Paste(_s) => sender.send(Event::Tick),
```
