### PR TITLE
fixed a typo in cargo install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ This tool is for when you don't need something as complex as Postman, but you al
 
 - **Prerequisites**: Make sure you have Rust and Cargo installed on your system.
 
- 1. `cargo install cute_tui`
+ 1. `cargo install cute-tui`
 
  2. make sure that your `~/.cargo/bin` directory is in your PATH
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ This tool is for when you don't need something as complex as Postman, but you al
 
 - **Prerequisites**: Make sure you have Rust and Cargo installed on your system.
 
- 1. `cargo install CuTe-tui`
+ 1. `cargo install CuTE-tui`
 
  2. make sure that your `~/.cargo/bin` directory is in your PATH
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ This tool is for when you don't need something as complex as Postman, but you al
 
 - **Prerequisites**: Make sure you have Rust and Cargo installed on your system.
 
- 1. `cargo install cute-tui`
+ 1. `cargo install CuTe-tui`
 
  2. make sure that your `~/.cargo/bin` directory is in your PATH
 


### PR DESCRIPTION
The installation instructions for `cargo install` had the wrong package name (`cute_tui` intsead of `CuTE-tui`). This pr fixes this small typo.